### PR TITLE
fix the cleanup, module needs some extra params now

### DIFF
--- a/delete_vsi.yml
+++ b/delete_vsi.yml
@@ -36,10 +36,8 @@
     name: "{{ name_prefix }}{{ item }}-vsi"
     state: absent
     id: "{{ vsi.resource.id }}"
-    vpc: "{{ vpc.resource.id }}"
-    keys:
-      - "{{ ssh_key.resource.id }}"
     zone: "{{ zone }}"
+    instance_template: ""
     wait_before_delete: True
   register: vsi_delete_output
   ignore_errors: True


### PR DESCRIPTION
With the latest collection release of ibm cloud 1.28.0, instance destroying has stopped working because of the new param which is needed. This PR adds the extra needed param to the playbook