### PR TITLE
Initial attempt to support the deployment of both Tower and Isolated node cluster on ibmcloud

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -1,11 +1,8 @@
 ---
-- name: Cleanup IBM Cloud VPC VSI
+- name: Cleanup IBM Cloud VPC VSI Related to Tower and Database Nodes
   hosts: localhost
-  vars:
-    - tower_node: []
-    - db_node: []
   collections:
-   - ibm.cloudcollection
+  - ibm.cloudcollection
   tasks:
     - name: Fetch the variables from var file
       include_vars:
@@ -13,16 +10,70 @@
 
     - name: Delete the VM's
       include_tasks: delete_vsi.yml
-      loop: "{{ range(1, ic_instance | int + 1, 1)|list }}"
+      loop: "{{ range(1, ic_instance|int + 1, 1)|list }}"
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
+        ic_instance: "{{ ibmcloud_vsi_db_count|int + ibmcloud_vsi_count|int }}"
 
     - name: Delete SSH Key
       include_role:
         name: delete_ssh
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
 
     - name: Delete VPC Subnet
       include_role:
         name: delete_vpc_subnet
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
 
     - name: Delete VPC
       include_role:
         name: delete_vpc
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
+
+- name: Cleanup IBM Cloud VPC VSI Related to Isolated Nodes
+  hosts: localhost
+  collections:
+  - ibm.cloudcollection
+  tasks:
+  - name: Should I Delete Isolated Nodes ??
+    when: install_iso|bool and ibmcloud_vsi_iso_instance_count|int > 0
+    block:
+    - name: Fetch the variables from var file
+      include_vars:
+        file: vars.yml
+
+    - name: Delete the VM's
+      include_tasks: delete_vsi.yml
+      loop: "{{ range(1, ic_instance|int + 1, 1)|list }}"
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+        ic_instance: "{{ ibmcloud_vsi_iso_instance_count|int }}"
+
+    - name: Delete SSH Key
+      include_role:
+        name: delete_ssh
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+
+    - name: Delete VPC Subnet
+      include_role:
+        name: delete_vpc_subnet
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+
+    - name: Delete VPC
+      include_role:
+        name: delete_vpc
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"

--- a/cleanup.yml
+++ b/cleanup.yml
@@ -14,8 +14,17 @@
       vars:
         name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
         ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
-        ic_instance: "{{ ibmcloud_vsi_db_count|int + ibmcloud_vsi_count|int }}"
+        ic_instance: "{{ ibmcloud_vsi_count|int }}"
 
+    - name: Delete the VM's
+      include_tasks: delete_vsi.yml
+      loop: "{{ range(ic_instance|int + 1, ic_instance|int + 2, 1)|list }}"
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
+        ic_instance: "{{ ibmcloud_vsi_count|int }}"
+      when: install_tower | bool
+        
     - name: Delete SSH Key
       include_role:
         name: delete_ssh

--- a/create.yml
+++ b/create.yml
@@ -1,11 +1,12 @@
 ---
 - name: Create IBM Cloud VPC VSI
+  gather_facts: off
   hosts: localhost
   vars:
     tower_node: []
-    db_node: []   
+    db_node: []
   collections:
-   - ibm.cloudcollection
+  - ibm.cloudcollection
   tasks:
     - name: Fetch the variables from var file
       include_vars:
@@ -14,33 +15,137 @@
     - name: Configure VPC
       include_role:
         name: configure_vpc
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
 
     - name: Configure VPC Subnet
       include_role:
         name: configure_vpc_subnet
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
 
     - name: Configure SSH Key
       include_role:
         name: configure_ssh
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
 
-    - name: Install the VM's
+    - name: Install the VM's for Tower
       include_tasks: create_vsi.yml
       loop: "{{ range(1, ic_instance |int + 1, 1)|list }}"
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
+        vsi_profile: "{{ ibmcloud_vsi_profile }}"
+        image_id: "{{ ibmcloud_vsi_image_id }}"
+        ic_instance: "{{ ibmcloud_vsi_count }}"
+
+    - name: Install the VM's for Database
+      include_tasks: create_vsi.yml
+      loop: "{{ range(ibmcloud_vsi_count|int + 1, ic_instance|int + 1, 1)|list }}"
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
+        vsi_profile: "{{ ibmcloud_vsi_db_profile }}"
+        image_id: "{{ ibmcloud_vsi_image_id }}"
+        ic_instance: "{{ ibmcloud_vsi_db_count|int + ibmcloud_vsi_count|int }}"
+
+    - name: Save Floating IP's of Tower of Database
+      set_fact:
+        tower_node: "{{ ibmcloud_vsi_node[:ibmcloud_vsi_count|int:] }}"
+        db_node: "{{ [ ibmcloud_vsi_node[-1] ] }}"
+        cacheable: True
 
     - name: Configure Security Group Rule
       include_role:
         name: configure_security_group
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
 
     - name: Add VM's to Tower and Database group
       include_role:
         name: add_hosts
+      when: install_tower | bool
+
+    - name: Print IBM Cloud Instance Floating IPs
+      debug:
+        msg: 
+          - "IC instance Floating IP: "
+          - "Tower: {{ tower_node }}"
+          - "Database: {{ db_node }}"
+
+- name: Create IBM Cloud VPC VSI for Tower Isolated Nodes
+  hosts: localhost
+  gather_facts: off
+  vars:
+    iso_node: []
+  collections:
+  - ibm.cloudcollection
+  tasks:
+  - name: Should I Install Isolated Nodes ??
+    when: install_iso|bool and ibmcloud_vsi_iso_instance_count|int > 0
+    block:
+    - name: Fetch the variables from var file
+      include_vars:
+        file: vars.yml
+
+    - name: Configure VPC
+      include_role:
+        name: configure_vpc
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+
+    - name: Configure VPC Subnet
+      include_role:
+        name: configure_vpc_subnet
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+
+    - name: Configure SSH Key
+      include_role:
+        name: configure_ssh
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+
+    - name: Install the VM's for Isolated Nodes
+      include_tasks: create_vsi.yml
+      loop: "{{ range(1, ic_instance |int + 1, 1)|list }}"
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+        vsi_profile: "{{ ibmcloud_vsi_iso_profile }}"
+        image_id: "{{ ibmcloud_vsi_iso_image_id }}"
+        ic_instance: "{{ ibmcloud_vsi_iso_instance_count }}"
+
+    - name: Save Floating IP's of Isolated Nodes
+      set_fact:
+        iso_node: "{{ ibmcloud_vsi_node[ibmcloud_vsi_count|int + ibmcloud_vsi_db_count|int::] }}"
+        cacheable: True
+
+    - name: Configure Security Group Rule
+      include_role:
+        name: configure_security_group
+      vars:
+        name_prefix: "{{ ibmcloud_vpc_iso_name_prefix }}"
+        ibmcloud_ic_region: "{{ ibmcloud_vpc_iso_region }}"
+
+    - name: Add VM's to Isolated group
+      include_role:
+        name: add_iso_hosts 
       when: install_tower | default('True') | bool
 
     - name: Print IBM Cloud Instance Floating IPs
       debug:
         msg: 
           - "IC instance Floating IP: "
-          - "{{ tower_node + db_node }}"
+          - "Isolated Nodes: {{ iso_node }}"
 
 - name: Check Ansible connection to new DEMO VSI
   hosts: tower database

--- a/create.yml
+++ b/create.yml
@@ -45,19 +45,25 @@
 
     - name: Install the VM's for Database
       include_tasks: create_vsi.yml
-      loop: "{{ range(ibmcloud_vsi_count|int + 1, ic_instance|int + 1, 1)|list }}"
+      loop: "{{ range(ic_instance|int + 1, ic_instance|int + 2, 1)|list }}"
       vars:
         name_prefix: "{{ ibmcloud_vpc_name_prefix }}"
         ibmcloud_ic_region: "{{ ibmcloud_vpc_region }}"
         vsi_profile: "{{ ibmcloud_vsi_db_profile }}"
         image_id: "{{ ibmcloud_vsi_image_id }}"
-        ic_instance: "{{ ibmcloud_vsi_db_count|int + ibmcloud_vsi_count|int }}"
+        ic_instance: "{{ ibmcloud_vsi_count }}"
+      when: install_tower | bool
 
     - name: Save Floating IP's of Tower of Database
       set_fact:
         tower_node: "{{ ibmcloud_vsi_node[:ibmcloud_vsi_count|int:] }}"
+        cacheable: True
+
+    - name: Save Floating IP's of Tower of Database
+      set_fact:
         db_node: "{{ [ ibmcloud_vsi_node[-1] ] }}"
         cacheable: True
+      when: install_tower | bool
 
     - name: Configure Security Group Rule
       include_role:
@@ -75,8 +81,7 @@
       debug:
         msg: 
           - "IC instance Floating IP: "
-          - "Tower: {{ tower_node }}"
-          - "Database: {{ db_node }}"
+          - "{{ ibmcloud_vsi_node }}"
 
 - name: Create IBM Cloud VPC VSI for Tower Isolated Nodes
   hosts: localhost
@@ -126,7 +131,7 @@
 
     - name: Save Floating IP's of Isolated Nodes
       set_fact:
-        iso_node: "{{ ibmcloud_vsi_node[ibmcloud_vsi_count|int + ibmcloud_vsi_db_count|int::] }}"
+        iso_node: "{{ ibmcloud_vsi_node[ibmcloud_vsi_count|int + 1::] }}"
         cacheable: True
 
     - name: Configure Security Group Rule

--- a/create_vsi.yml
+++ b/create_vsi.yml
@@ -12,6 +12,7 @@
      primary_network_interface:
        - subnet: "{{ subnet.id }}"
      zone: "{{ vpc_zone.name }}"
+     region: "{{ ibmcloud_ic_region }}"
   register: vsi_create_output
 
 - name: Save VSI as fact
@@ -23,6 +24,7 @@
   ibm.cloudcollection.ibm_is_floating_ip:
      name: "{{ name_prefix }}{{ item }}-fip"
      state: available
+     region: "{{ ibmcloud_ic_region }}"
      #id: "{{ fip.id | default(omit) }}"
      target: "{{ vsi.primary_network_interface[0]['id'] }}"
   register: fip_create_output
@@ -30,11 +32,4 @@
 - name: Save Floating IPs 
   set_fact:
      cacheable: True
-     tower_node: "{{ tower_node + [fip_create_output.resource.address] }}"
-  when: item != ic_instance 
-
-- name: Save Floating IPs
-  set_fact:
-     cacheable: True
-     db_node: "{{ db_node + [fip_create_output.resource.address] }}"
-  when: item == ic_instance
+     ibmcloud_vsi_node: "{{ ibmcloud_vsi_node|default([]) + [fip_create_output.resource.address] }}"

--- a/delete_vsi.yml
+++ b/delete_vsi.yml
@@ -2,6 +2,7 @@
 - name: Fetch Floating IP of the VM's
   ibm.cloudcollection.ibm_is_floating_ip_info:
     name: "{{ name_prefix }}{{ item }}-fip"
+    region: "{{ ibmcloud_ic_region }}"
   register: fip
   ignore_errors: True
 
@@ -10,18 +11,21 @@
     name: "{{ name_prefix }}{{ item }}-fip"
     state: absent
     id: "{{ fip.resource.id }}"
+    region: "{{ ibmcloud_ic_region }}"
   register: fip_delete_output
   ignore_errors: True
 
 - name: Fetch VSI details
   ibm.cloudcollection.ibm_is_instance_info:
     name: "{{ name_prefix }}{{ item }}-vsi"
+    region: "{{ ibmcloud_ic_region }}"
   register: vsi
   ignore_errors: True
 
 - name: Fetch VPC details
   ibm.cloudcollection.ibm_is_vpc_info:
     name: "{{ name_prefix }}-vpc"
+    region: "{{ ibmcloud_ic_region }}"
   register: vpc
   ignore_errors: True
 
@@ -33,5 +37,6 @@
     zone: "{{ vpc.resource.subnets[-1].zone }}"
     instance_template: ""
     wait_before_delete: True
+    region: "{{ ibmcloud_ic_region }}"
   register: vsi_delete_output
   ignore_errors: True

--- a/roles/add_iso_hosts/tasks/main.yml
+++ b/roles/add_iso_hosts/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Add Isolated nodes to iso group
+  add_host:
+    name: "{{ item }}"
+    ansible_user: root
+    groups: iso
+    ansible_ssh_extra_args: -o StrictHostKeyChecking=no
+    ansible_ssh_private_key_file: conf/towerperf_id_rsa
+  loop: "{{ iso_node }}"

--- a/roles/configure_security_group/tasks/main.yml
+++ b/roles/configure_security_group/tasks/main.yml
@@ -3,6 +3,7 @@
   ibm.cloudcollection.ibm_is_security_group_rule:
     state: available
     group: "{{ vpc.default_security_group }}"
+    region: "{{ ibmcloud_ic_region }}"
     direction: inbound
     remote: 0.0.0.0/0
     tcp:
@@ -14,6 +15,7 @@
   ibm.cloudcollection.ibm_is_security_group_rule:
     state: available
     group: "{{ vpc.default_security_group }}"
+    region: "{{ ibmcloud_ic_region }}"
     direction: inbound
     remote: 0.0.0.0/0
     icmp:

--- a/roles/configure_ssh/tasks/main.yml
+++ b/roles/configure_ssh/tasks/main.yml
@@ -3,7 +3,8 @@
   ibm.cloudcollection.ibm_is_ssh_key:
     name: "{{ name_prefix }}-ssh-key"
     public_key: "{{ ssh_public_key }}"
-    id: "{{ ssh_key.id | default(omit) }}"
+    #id: "{{ ssh_key.id | default(omit) }}"
+    region: "{{ ibmcloud_ic_region }}"
   register: ssh_key_create_output
 
 - name: Save SSH Key as fact

--- a/roles/configure_vpc/tasks/main.yml
+++ b/roles/configure_vpc/tasks/main.yml
@@ -3,7 +3,8 @@
   ibm.cloudcollection.ibm_is_vpc:
     name: "{{ name_prefix }}-vpc"
     state: available
-    id: "{{ vpc.id | default(omit) }}"
+    #id: "{{ vpc.id | default(omit) }}"
+    region: "{{ ibmcloud_ic_region }}"
   register: vpc_create_output
 
 - name: Save VPC as fact
@@ -14,6 +15,7 @@
 - name: Retrieve VPC Address prefixes
   ibm.cloudcollection.ibm_is_vpc_address_prefixes_info:
     vpc: "{{ vpc.id }}"
+    region: "{{ ibmcloud_ic_region }}"
   register: vpc_address_prefixes
 
 - name: Save VPC zones as fact
@@ -25,5 +27,4 @@
 
 - name: Save VPC zone and cidr mapping
   set_fact:
-    vpc_zone: "{{ vpc_zone_name_cidr | random }}" 
-
+    vpc_zone: "{{ vpc_zone_name_cidr | random }}"

--- a/roles/configure_vpc_subnet/tasks/main.yml
+++ b/roles/configure_vpc_subnet/tasks/main.yml
@@ -3,10 +3,11 @@
   ibm.cloudcollection.ibm_is_subnet:
     name: "{{ name_prefix }}-subnet"
     state: available
-    id: "{{ subnet.id | default(omit) }}"
+    #id: "{{ subnet.id | default(omit) }}"
     vpc: "{{ vpc.id }}"
     ipv4_cidr_block: "{{ vpc_zone.cidr }}"
     zone: "{{ vpc_zone.name }}"
+    region: "{{ ibmcloud_ic_region }}"
   register: subnet_create_output
 
 - name: Save VPC Subnet as fact

--- a/roles/delete_ssh/tasks/main.yml
+++ b/roles/delete_ssh/tasks/main.yml
@@ -2,15 +2,17 @@
 - name: Fetch SSH Keys Details
   ibm.cloudcollection.ibm_is_ssh_key_info:
     name: "{{ name_prefix }}-ssh-key"
+    region: "{{ ibmcloud_ic_region }}"
   register: ssh_key
   ignore_errors: True
 
-- name: Configure SSH Key
+- name: Cleanup SSH Key
   ibm.cloudcollection.ibm_is_ssh_key:
     name: "{{ name_prefix }}-ssh-key"
     public_key: "{{ ssh_public_key }}" 
     id: "{{ ssh_key.resource.id }}"
     state: absent
+    region: "{{ ibmcloud_ic_region }}"
   register: ssh_key_delete_output
   ignore_errors: True
 

--- a/roles/delete_vpc/tasks/main.yml
+++ b/roles/delete_vpc/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Fetch VPC details
   ibm.cloudcollection.ibm_is_vpc_info:
     name: "{{ name_prefix }}-vpc"
+    region: "{{ ibmcloud_ic_region }}"
   register: vpc
   ignore_errors: True
 
@@ -10,5 +11,6 @@
     name: "{{ name_prefix }}-vpc"
     id: "{{ vpc.resource.id }}"
     state: absent
+    region: "{{ ibmcloud_ic_region }}"
   register: vpc_delete_output
   ignore_errors: True

--- a/roles/delete_vpc_subnet/tasks/main.yml
+++ b/roles/delete_vpc_subnet/tasks/main.yml
@@ -2,15 +2,17 @@
 - name: Fetch VPC Subnet
   ibm.cloudcollection.ibm_is_subnet_info:
     name: "{{ name_prefix }}-subnet"
+    region: "{{ ibmcloud_ic_region }}"
   register: subnet
   ignore_errors: True
 
-- name: delete VPC Subnet
+- name: Delete VPC Subnet
   ibm.cloudcollection.ibm_is_subnet:
     name: "{{ name_prefix }}-subnet"
     vpc: "{{ subnet.resource.vpc }}"
     zone: "{{ subnet.resource.zone }}"
     id: "{{ subnet.resource.id }}"
+    region: "{{ ibmcloud_ic_region }}"
     state: absent
   register: subnet_delete_output
   ignore_errors: True

--- a/templates/inventory_cluster.j2
+++ b/templates/inventory_cluster.j2
@@ -3,6 +3,15 @@
 {{ host }} 
 {% endfor %}{# for host in groups['tower'] #}
 
+{% if groups['iso']|default([])|length > 0 %}
+[isolated_group_restrictedzone]
+{% for isonode in groups['iso'] %}
+{{ isonode }}
+{% endfor %}
+
+[isolated_group_restrictedzone:vars]
+controller=tower
+{% endif %}
 
 [database]
 {% for host in groups['database'] %}

--- a/vars.yml
+++ b/vars.yml
@@ -15,7 +15,6 @@ install_tower: True
 
 # Ansible Tower and Tower database must be in the same 
 ibmcloud_vsi_db_profile: 'bx2-4x16'
-ibmcloud_vsi_db_count: 1    # Required database nodes should be always 1
 
 
 # Isolated Nodes must be in the different region compared to Controller

--- a/vars.yml
+++ b/vars.yml
@@ -1,13 +1,35 @@
 ---
-name_prefix: ansible-tower-test
-vsi_image: ibm-redhat-8-3-minimal-amd64-3
-vsi_profile: bx2-4x16
-#ssh_public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC2xCcL+l/hHGI0s8qfx3sm9JV4tnTSmYzimr7t4KmYEi+RUODyKtvU+LkyedYGhdWXIMgx5yajafAoz8oacMX+SctNa9RAXz31pBC53rztKYnlvly806BXg6s0fTei1gtVt5SGhApviWGVjyQ89CkON1rM41mBqiS9015ND3D2kYBVu3g1+0t/6Tp4bSZpIdFAAf95jDtkqTMo04+c73JqQA/pyXguU7NpAmIC7YMyRXwow8Q0UTiBkcgk7Z9/HCxXz7elfx48nTko3HHgwTublODLdnOiG1BgWESLtLP5H+NvU22bUJ32nnN1WQ9RhrMHxcb8H4TsKLM257fT0I5O8an8TQ/ulhX3+pO1SFpdv6NVAgmhokIjP08VHPYknn8V5GO0q5wx11/8Gk4eT8LKrjhLJThongXxbAWKBz9pVpsnumvQH8F1i9MduJxbq980ZjRAjyNvz2RuN5RFWixCTPidpqtNi1p6uoBSyNvTZ5TzpnJhwtdxAKpL9qX6PZ8= root@localhost-localdomain'
-  #total_ipv4_address_count: 256
-ssh_public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDlkniCZbiIhOv9RkoSE73Yg4sjRtuiuXWKHBCvhQ9BxZV33rMEGCUwYs2XT8QWbuJxBg+aXspZ1Of00lNV1S2/Ukg4n6Os7szI6mqJQgFR/oqLckGbHML76CdvwQ1iVoSFdE5bieQdfbK+LmIRVQAzO93090jWtWaJ8MkxzgarvXpPcwidVjB/PDsIq3NG/6boH/xUhxRH/Qt+4ShVH0/w4YTLGAvp56yeN+1XWoGy/D0V7JQX9y82ca3n9S+DsYAJBcUp/k7rjqtEsNBDYpNk7nvjmt9jiXCVCBu6EajcINOa/uEsWsyX/iyxE6XENsBP+hPK7/HMEqvMJw2cfJakCHCLTRpYZSOS4fursT53ZXt+UWko8S2xIqt/kkH4HSvrfHejlUWGILlRhEKX6SfMQaLLWaqz8QT9LIhEY/gRjk4wekAYWSQziaMeEcUsLVITihLKKG8qw6+ig5TOlw6LAhBJxCsKPkWLul7wAP5j6mI9/M73nX8JXX3O/drcNR0= pok@localhost.localdomain'
-image_id: 'r022-939bbfe2-d823-4c01-98a3-a6f8193731d8'
+# Ansible Tower Installation
 #installation_tarball: https://releases.ansible.com/ansible-tower/setup-bundle/ansible-tower-setup-bundle-latest.tar.gz
 installation_tarball: http://perf54.perf.lab.eng.bos.redhat.com/pub/ansible-automation-platform-setup-bundle-2.0.0-1-early-access.tar.gz
-ic_instance: 3
-list_of_ports: [22, 80, 443, 5432, 9121, 9256, 9117, 9393, 9392, 9187, 9100]
 inventory_template: inventory_cluster_4.j2
+
+# Tower and the Database must be in the same Region and in the same VPC
+ibmcloud_vpc_name_prefix: 'ansible-tower-test'
+ibmcloud_vpc_region: 'jp-tok'    # Tokyo
+ibmcloud_vpc_image_name: 'ibm-redhat-8-3-minimal-amd64-3'
+ibmcloud_vsi_image_id: 'r022-939bbfe2-d823-4c01-98a3-a6f8193731d8'
+ibmcloud_vsi_profile: 'bx2-4x16'
+ibmcloud_vsi_count: 2 
+install_tower: True
+
+# Ansible Tower and Tower database must be in the same 
+ibmcloud_vsi_db_profile: 'bx2-4x16'
+ibmcloud_vsi_db_count: 1    # Required database nodes should be always 1
+
+
+# Isolated Nodes must be in the different region compared to Controller
+ibmcloud_vpc_iso_name_prefix: 'ansible-tower-iso-test'
+ibmcloud_vpc_iso_region: 'eu-gb'    # London   
+ibmcloud_vsi_iso_image_name: 'ibm-redhat-8-3-minimal-amd64-3'
+ibmcloud_vsi_iso_image_id: 'r018-179f9b5c-0e4d-4614-8fbb-07e8ec55a493'
+ibmcloud_vsi_iso_profile: 'bx2-4x16'
+ibmcloud_vsi_iso_instance_count: 0
+install_iso: False 
+
+# Required ports for SSH, Tower, Exporters
+list_of_ports: [22, 80, 443, 5432, 9121, 9256, 9117, 9393, 9392, 9187, 9100]
+#ssh_public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC2xCcL+l/hHGI0s8qfx3sm9JV4tnTSmYzimr7t4KmYEi+RUODyKtvU+LkyedYGhdWXIMgx5yajafAoz8oacMX+SctNa9RAXz31pBC53rztKYnlvly806BXg6s0fTei1gtVt5SGhApviWGVjyQ89CkON1rM41mBqiS9015ND3D2kYBVu3g1+0t/6Tp4bSZpIdFAAf95jDtkqTMo04+c73JqQA/pyXguU7NpAmIC7YMyRXwow8Q0UTiBkcgk7Z9/HCxXz7elfx48nTko3HHgwTublODLdnOiG1BgWESLtLP5H+NvU22bUJ32nnN1WQ9RhrMHxcb8H4TsKLM257fT0I5O8an8TQ/ulhX3+pO1SFpdv6NVAgmhokIjP08VHPYknn8V5GO0q5wx11/8Gk4eT8LKrjhLJThongXxbAWKBz9pVpsnumvQH8F1i9MduJxbq980ZjRAjyNvz2RuN5RFWixCTPidpqtNi1p6uoBSyNvTZ5TzpnJhwtdxAKpL9qX6PZ8= root@localhost-localdomain'
+
+ssh_public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDlkniCZbiIhOv9RkoSE73Yg4sjRtuiuXWKHBCvhQ9BxZV33rMEGCUwYs2XT8QWbuJxBg+aXspZ1Of00lNV1S2/Ukg4n6Os7szI6mqJQgFR/oqLckGbHML76CdvwQ1iVoSFdE5bieQdfbK+LmIRVQAzO93090jWtWaJ8MkxzgarvXpPcwidVjB/PDsIq3NG/6boH/xUhxRH/Qt+4ShVH0/w4YTLGAvp56yeN+1XWoGy/D0V7JQX9y82ca3n9S+DsYAJBcUp/k7rjqtEsNBDYpNk7nvjmt9jiXCVCBu6EajcINOa/uEsWsyX/iyxE6XENsBP+hPK7/HMEqvMJw2cfJakCHCLTRpYZSOS4fursT53ZXt+UWko8S2xIqt/kkH4HSvrfHejlUWGILlRhEKX6SfMQaLLWaqz8QT9LIhEY/gRjk4wekAYWSQziaMeEcUsLVITihLKKG8qw6+ig5TOlw6LAhBJxCsKPkWLul7wAP5j6mI9/M73nX8JXX3O/drcNR0= pok@localhost.localdomain'
+

--- a/vars.yml
+++ b/vars.yml
@@ -24,7 +24,7 @@ ibmcloud_vpc_iso_region: 'eu-gb'    # London
 ibmcloud_vsi_iso_image_name: 'ibm-redhat-8-3-minimal-amd64-3'
 ibmcloud_vsi_iso_image_id: 'r018-179f9b5c-0e4d-4614-8fbb-07e8ec55a493'
 ibmcloud_vsi_iso_profile: 'bx2-4x16'
-ibmcloud_vsi_iso_instance_count: 0
+ibmcloud_vsi_iso_instance_count: 1
 install_iso: False 
 
 # Required ports for SSH, Tower, Exporters


### PR DESCRIPTION
#### Highlights of the PR
1. Ability to create/delete Isolated nodes for the Tower deployment

As discussed on the chat, Tower and Isolated nodes must be in the different regions. To support this, added a new `play` that uses the existing roles and a keyword `region` for creating isolated nodes in a different region. Running cleanup job will delete all the nodes from two different regions.

2. Ability to define a new `instance_profile` for a database node

So far we have been creating database node with same H/w specification as Tower node. But now we can specify different `instance_profile` or H/w specifications for a database node. I also made sure both Tower and Database nodes are getting created in the same region

3. Added isolated node setup inventory changes to `templates/inventory_cluster.j2` 
4. Default, Tower and Database nodes will be created in `Tokyo` region and Isolated nodes in `London` region
5. Default, Isolated setup is disabled. To enable it, run the playbook with `install_iso: True` and `ibmcloud_vsi_iso_instance_count: N > 0`


Playbook `create.yml` and `cleanup.yml` dry-runs are clean without any errors