### PR TITLE
templates/inventory_towerperf: deploy monitoring on tower isolated nodes

### DIFF
--- a/templates/inventory_towerperf.j2
+++ b/templates/inventory_towerperf.j2
@@ -3,6 +3,12 @@
 {{ host }} ansible_ssh_private_key_file=conf/towerperf_id_rsa 
 {% endfor %}{# for host in groups['tower'] #}
 
+{% if groups['iso']|default([])|length > 0 %}
+[iso_servers]
+{% for isonode in groups['iso'] %}
+{{ isonode }}
+{% endfor %}
+{% endif %}
 
 [database]
 {% for host in groups['database'] %}


### PR DESCRIPTION
Create a new section called "iso_servers" in the inventory to setup node and process exporters in Tower isolated nodes.

closes https://github.com/jainnikhil30/ibm_cloud_tower_deploy/issues/11
