### PR TITLE
templates: added private key file for isolated node

### DIFF
--- a/templates/inventory_towerperf.j2
+++ b/templates/inventory_towerperf.j2
@@ -6,7 +6,7 @@
 {% if groups['iso']|default([])|length > 0 %}
 [iso_servers]
 {% for isonode in groups['iso'] %}
-{{ isonode }}
+{{ isonode }} ansible_ssh_private_key_file=conf/towerperf_id_rsa
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
To fix the following errors during the monitoring setup

```
TASK [Extract node exporter archive] *******************************************
Tuesday 24 August 2021  10:49:25 +0000 (0:00:00.036)       0:00:00.036 ******** 
fatal: [161.156.203.117]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Warning: Permanently added '161.156.203.117' (ECDSA) to the list of known hosts.\r\nroot@161.156.203.117: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).", "unreachable": true}
```